### PR TITLE
Styling and minor functionality updates for compatability with Kano.me

### DIFF
--- a/kano-cart/kano-cart.html
+++ b/kano-cart/kano-cart.html
@@ -15,6 +15,7 @@ Example:
 -->
 
 <dom-module id="kano-cart">
+    <style is="custom-style"></style>
     <style>
         :host {
             display: block;
@@ -58,7 +59,7 @@ Example:
             margin: 0;
             padding: 15px;
             position: absolute;
-            top: 45px;
+            top: 62px;
         }
         :host .all-regions::before {
             color: #ffffff;
@@ -77,9 +78,10 @@ Example:
             @apply(--layout-horizontal);
             @apply(--layout-center);
             @apply(--layout-end-justified);
+            height: 100%;
         }
         :host .region-selector {
-            @apply(--layout-flex-2);
+            flex: 2 0 auto;
         }
         :host .region
         :host .current-region,
@@ -113,7 +115,7 @@ Example:
             width: 2.2rem;
         }
         :host .cart-icon {
-            height: auto;
+            height: 1.6rem;
             margin: 0.3rem;
             width: 1.6rem;
         }
@@ -134,7 +136,7 @@ Example:
             position: absolute;
             right: -5px;
             text-align: center;
-            top: -5px;
+            top: 5px;
             width: 22px;
         }
         @media all and (max-width: 840px) {
@@ -190,7 +192,8 @@ Example:
         </a>
     </template>
 </dom-module>
-<script type="text/javascript">
+
+<script>
     Polymer({
         is: 'kano-cart',
         properties: {

--- a/kano-nav/kano-nav.html
+++ b/kano-nav/kano-nav.html
@@ -21,6 +21,7 @@ Custom property | Description | Default
 -->
 
 <dom-module id="kano-nav">
+    <style is="custom-style"></style>
     <style>
         @keyframes slideInLeft {
             from {
@@ -272,6 +273,7 @@ Custom property | Description | Default
         </nav>
     </template>
 </dom-module>
+
 <script>
     Polymer({
         is: 'kano-nav',

--- a/kano-primary-links/kano-primary-links.html
+++ b/kano-primary-links/kano-primary-links.html
@@ -13,6 +13,7 @@ Example:
 -->
 
 <dom-module id="kano-primary-links">
+    <style is="custom-style"></style>
     <style>
         :host {
             --dark-grey: #44423d;
@@ -132,7 +133,8 @@ Example:
         </ul>
     </template>
 </dom-module>
-<script type="text/javascript">
+
+<script>
     Polymer({
         is: 'kano-primary-links',
         properties: {
@@ -154,7 +156,8 @@ Example:
              * Basepath of the site to allow for testing across multiple environments
              */
             currentSite: {
-                type: String
+                type: String,
+                value: null
             },
             /**
              * Basepath of the store to allow for testing across multiple environments
@@ -188,15 +191,15 @@ Example:
         _computeLink: function (site, path, regionalize, currentSite, selectedRegion) {
             if (site !== currentSite) {
                 return site + path;
-            };
+            }
             if (regionalize === 'true') {
                 return path + '/' + selectedRegion;
-            };
+            }
             return path;
         },
         _computeLinkClass: function (site, paths, currentSite, selectedLink) {
-            var selectedPath = '/' + selectedLink;
-            var pathMatch = paths;
+            var selectedPath = '/' + selectedLink,
+                pathMatch = paths;
             if (Array.isArray(paths)) {
                 pathMatch = paths.join('|');
             }

--- a/kano-secondary-links/kano-secondary-links.html
+++ b/kano-secondary-links/kano-secondary-links.html
@@ -13,6 +13,7 @@ Example:
 -->
 
 <dom-module id="kano-secondary-links">
+    <style is="custom-style"></style>
     <style>
         :host {
             @apply(--layout-flex-none);
@@ -65,25 +66,26 @@ Example:
         }
     </style>
     <template>
-        <ul id="secondary-nav-items" class="nav-menu-items">
-            <li class="menu-item">
-                <a href$="[[_computeLink(storeRoot, '/educators', 'false', currentSite,  selectedRegion)]]" class$="link [[_computeLinkClass(storeRoot, '/educators', currentSite, selectedLink)]]">
-                  <span class="menu-item-label">
-                    Educators
-                  </span>
-                </a>
-            </li>
-            <li class="menu-item">
-                <a href$="[[_computeLink('http://blog.kano.me', '/', 'false',  currentSite, selectedRegion)]]" class$="link [[_computeLinkClass('http://blog.kano.me', '/', currentSite, selectedLink)]]">
-                  <span class="menu-item-label">
-                    Blog
-                  </span>
-                </a>
-            </li>
-        </ul>
+      <ul id="secondary-nav-items" class="nav-menu-items">
+          <li class="menu-item">
+              <a href$="[[_computeLink(storeRoot, '/educators', 'false', currentSite,  selectedRegion)]]" class$="link [[_computeLinkClass(storeRoot, '/educators', currentSite, selectedLink)]]">
+                <span class="menu-item-label">
+                  Educators
+                </span>
+              </a>
+          </li>
+          <li class="menu-item">
+              <a href$="[[_computeLink('http://blog.kano.me', '/', 'false',  currentSite, selectedRegion)]]" class$="link [[_computeLinkClass('http://blog.kano.me', '/', currentSite, selectedLink)]]">
+                <span class="menu-item-label">
+                  Blog
+                </span>
+              </a>
+          </li>
+      </ul>
     </template>
 </dom-module>
-<script type="text/javascript">
+
+<script>
     Polymer({
         is: 'kano-secondary-links',
         properties: {
@@ -105,7 +107,8 @@ Example:
              * Basepath of the site to allow for testing across multiple environments
              */
             currentSite: {
-                type: String
+                type: String,
+                value: null
             },
             /**
              * Basepath of the store to allow for testing across multiple environments
@@ -125,10 +128,10 @@ Example:
         _computeLink: function (site, path, regionalize, currentSite, selectedRegion) {
             if (site !== currentSite) {
                 return site + path;
-            };
+            }
             if (regionalize === 'true') {
                 return path + '/' + selectedRegion;
-            };
+            }
             return path;
         },
         _computeLinkClass: function (site, path, currentSite, selectedLink) {


### PR DESCRIPTION
* Adding close button to the mobile overlay
* Making `kano-secondary-links` active link classes more robust
* Simplifying how `kano-cart` images are loaded, and regions processed
* Some tidying up and correcting indentation

Trello card: https://trello.com/c/n4koEAte/1697-2-implement-global-navigation-on-kano-me-and-start-page