### PR TITLE
Update 'skip' copy to 'Sign up later' for consistency with link text

### DIFF
--- a/kano-auth/kano-auth.html
+++ b/kano-auth/kano-auth.html
@@ -210,7 +210,7 @@
                     <h2>Now go find your mum or dad!</h2>
                     <div class="body">
                         Ask a parent, teacher or guardian to help you (it'll take less than a minute).
-                        If they can't help right now, press 'skip'.
+                        If they can't help right now, press 'Sign up later'.
                     </div>
                     <form on-submit="grownupsSection">
                         <fieldset>


### PR DESCRIPTION
Trello card: https://trello.com/c/ISpwxXmm/1724-kano-code-on-signup-the-text-say-if-not-able-click-skip-but-there-are-not-skip-button