### PR TITLE
Remove fixed nav options, and simplify component

### DIFF
--- a/kano-nav/kano-nav.html
+++ b/kano-nav/kano-nav.html
@@ -10,7 +10,7 @@ across all kano online products. It also displays user navigation and notificati
 
 Example:
 
-    <kano-nav assets-path="./assets/navbar/" fixed site-root="/"></kano-nav>
+    <kano-nav assets-path="./assets/navbar/" site-root="/"></kano-nav>
 
 @group Kano Elements
 @demo ./kano-nav/demo/kano-nav.html


### PR DESCRIPTION
As of the requests on the Trello card below, the fixed display options are no longer needed on the `kano-nav`, so the fixed properties, styles, and all related functionality has been removed. Other optional aspects and the `--kano-nav` mixin have been removed to simplify things in line with current needs. In cases where the nav is to be fixed, this can be styled from the container app.

Trello card: https://trello.com/c/hcNI7mIL/6-1-make-the-primary-nav-visible-on-scroll-on-kano-me