### PR TITLE
Add observer for app property of kano-share-feed, and reset if necessary

### DIFF
--- a/kano-share-feed/kano-share-feed.html
+++ b/kano-share-feed/kano-share-feed.html
@@ -104,7 +104,7 @@
                 },
                 assetsPath: {
                     type: String,
-                    value: '/assets'
+                    value: '/'
                 },
                 empty: {
                     type: Boolean,


### PR DESCRIPTION
Allows the `kano-share-feed` to be reset when the `app` property is changed, to allow for filters to be updated in the parent app.

Trello card: https://trello.com/c/93RDLNvb/101-1-feed1-on-electron-app-home-have-an-opt-in-feed-that-shows-all-creations-not-just-ones-filtered-by-pixel-kit