### PR TITLE
Restrict remixes to only those shares that match the current device

### DIFF
--- a/kano-share-card/kano-share-card.html
+++ b/kano-share-card/kano-share-card.html
@@ -232,6 +232,9 @@
             * flags in future, but this suffices for the moment.
             */
             _appIntegration (device, share) {
+                if (!device || !share) {
+                    return false;
+                }
                 return share.app === device;
             },
             _computeAvatar(share, assetsPath) {

--- a/kano-share-stats/kano-share-stats.html
+++ b/kano-share-stats/kano-share-stats.html
@@ -77,7 +77,7 @@
         </style>
         <div class="stats">
             <template is="dom-if" if="[[appIntegration]]">
-                <button class$="[[_computeKitClass(savedToDevice)]]" on-tap="_updateKit">
+                <button class$="[[_computeKitClass(savedToDevice)]]" type="button" on-tap="_updateKit">
                     <template is="dom-if" if="[[savedToDevice]]">
                         <iron-icon class="icon saved-to-device" icon="kano-icons:saved-to-device"></iron-icon>
                         <iron-icon class="icon remove-from-device" icon="kano-icons:remove-from-device"></iron-icon>
@@ -89,8 +89,7 @@
                     </template>
                 </button>
             </template>
-            <button class$="[[_computeLikeClass(liked)]]"
-                    on-tap="_onLikeTapped">
+            <button class$="[[_computeLikeClass(liked)]]" type="button" on-tap="_onLikeTapped">
                 <kano-particle-burst id="particle-burst"
                                number-particles="40"
                                gravity="0.5"
@@ -102,7 +101,7 @@
                 <span>&nbsp;likes</span>
             </button>
             <template is="dom-if" if="[[appIntegration]]">
-                <button class="remix" on-tap="_onRemixTapped">
+                <button class="remix" type="button" on-tap="_onRemixTapped">
                     <iron-icon class="icon" icon="kano-icons:remix"></iron-icon>
                     <span>Remix</span>
                 </button>


### PR DESCRIPTION
* Updates `sendToDevice` property to `appIntegration` to cover the `send-to-kit` and `remix` buttons, since both should be suppressed on shares that do not match the current device should not be remixed or sent to kit. This will need to be updated in future, but may then be able to take account of hardware tagging to achieve a more nuanced approach.

Fixes this issue: https://trello.com/c/bEBrfvq7/366-non-kano-code-shares-should-not-have-a-remix-option