### PR TITLE
Make kano-share-feed reset method public

### DIFF
--- a/kano-share-feed/kano-share-feed.html
+++ b/kano-share-feed/kano-share-feed.html
@@ -261,7 +261,7 @@
             _isDetailed (mode) {
                 return mode === 'detailed';
             },
-            _reset () {
+            reset () {
                 this.set('populated', false);
                 this.set('shares', []);
                 this.set('page', 0);


### PR DESCRIPTION
Fitting the naming convention to allow this to be called by parent components in a bid to fix this bug:

https://trello.com/c/m4k20ycL/423-scrolling-down-on-shares-then-opening-the-share-to-go-back-then-the-screen-with-shares-is-blank-until-you-scroll-again

Required for this PR, where the issue is explained in more detail: https://github.com/KanoComputing/kano2-app/pull/225