### PR TITLE
Update tracking behavior to use localStorage

### DIFF
--- a/kano-tracking/kano-tracking-behavior.html
+++ b/kano-tracking/kano-tracking-behavior.html
@@ -162,31 +162,23 @@
         _setSchema () {
             // When using Kano Code within the Electron app, we want to be able
             // to provide the app's schema in place of the default schema
-            this.schema = this._parseParams('tracking-schema') || this.context.config.TRACKING.SCHEMA;
+            this.schema = localStorage.getItem('KANO-TRACKING-SCHEMA') || this.context.config.TRACKING.SCHEMA;
         },
         _setIds () {
             let browserId = localStorage.getItem('KANO-TRACKING-BROWSER-ID'),
                 sessionId = sessionStorage.getItem('KANO-TRACKING-SESSION-ID'),
                 savedSessionId = localStorage.getItem('KANO-TRACKING-SESSION-ID'),
-                urlSessionId = this._parseParams('session-id'),
                 idString = window.navigator.userAgent + Date.now().toString(),
                 hashedId = md5(idString);
-            // If a `session-id` has been provided in the URL, then we always
-            // want this to take priority
-            if (urlSessionId) {
-                sessionId = urlSessionId;
-                sessionStorage.setItem('KANO-TRACKING-SESSION-ID', urlSessionId);
-                // If we already have a `sessionId`, then we can assume that
-                // the session has already been started
-                this.previousSession = true;
-            }
             // If a `session-id` has been saved in localStorage, then we want
             // make use of this to continue the session, and then clear
             // localStorage
             if (savedSessionId) {
                 sessionId = savedSessionId;
                 sessionStorage.setItem('KANO-TRACKING-SESSION-ID', savedSessionId);
-                localStorage.removeItem('KANO-TRACKING-SESSION-ID');
+                if (!this.preserveSavedSession) {
+                    localStorage.removeItem('KANO-TRACKING-SESSION-ID');
+                }
                 this.previousSession = true;
             }
             if (!browserId) {
@@ -209,21 +201,11 @@
                   return 'Unknown';
               });
         },
-        _parseParams (name) {
-            let qs = window.location.search,
-                regex,
-                result;
-            if (qs.length > 1) {
-                regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
-                result = regex.exec(qs);
-                if (result && result[2]) {
-                    return decodeURIComponent(result[2].replace(/\+/g, ' '));
-                }
-            }
-            return null;
-        },
         _saveSession () {
             localStorage.setItem('KANO-TRACKING-SESSION-ID', this.sessionId);
+        },
+        _saveSchema () {
+            localStorage.setItem('KANO-TRACKING-SCHEMA', this.schema);
         },
         _sessionExpired (lastUpdate) {
             if (!lastUpdate) {


### PR DESCRIPTION
Since Kano Code can access localStorage, there's no need for schema and sessionId to be passed in URL params. But Kano Code should not clear the saved sessionId, as this will be needed by the Electron app to preserve the previous session. Kano Code will now have a `preserveSavedSession` property to prevent this being cleared.

Required for: 
https://github.com/KanoComputing/make-apps/pull/972
https://github.com/KanoComputing/kano2-app/pull/234