### PR TITLE
Update lightboard preview background color

### DIFF
--- a/kano-lightboard-preview/kano-lightboard-preview.html
+++ b/kano-lightboard-preview/kano-lightboard-preview.html
@@ -16,6 +16,7 @@ Example:
 <dom-module id="kano-lightboard-preview">
     <style>
         #canvas {
+            background-color: #22272d;
             image-rendering: pixelated;
         }
     </style>

--- a/kano-share-feed/kano-share-feed.html
+++ b/kano-share-feed/kano-share-feed.html
@@ -206,7 +206,7 @@
             },
             _handleChanges () {
                 if (this.populated) {
-                    this._reset();
+                    this.reset();
                 }
             },
             _loadMoreData () {
@@ -261,7 +261,7 @@
             _isDetailed (mode) {
                 return mode === 'detailed';
             },
-            _reset () {
+            reset () {
                 this.set('populated', false);
                 this.set('shares', []);
                 this.set('page', 0);


### PR DESCRIPTION
Fixes this bug: https://trello.com/c/boSfhsG0/428-animated-share-covers-16-x-8

Also changes `kano-share-feed` method `_reset` to `reset` to fit public convention and match recent changes in the app.