### PR TITLE
Abort share fetches if the current user has changed

### DIFF
--- a/kano-share-feed/kano-share-feed.html
+++ b/kano-share-feed/kano-share-feed.html
@@ -180,6 +180,14 @@
                     type: String,
                     value: 'detailed'
                 },
+                /**
+                * Whether the feed has been populated with entries for the
+                * current settings
+                */
+                populated: {
+                    type: Boolean,
+                    value: false
+                },
                 shares: {
                     type: Array,
                     value: () => {
@@ -204,7 +212,12 @@
                 //need to fire resize event to refresh scroller value
                 window.dispatchEvent(new Event('resize'));
             },
-            _handleChanges () {
+            _handleChanges (current, previous) {
+                if (this.fetching) {
+                    // If the component is already fetching data, set the flag
+                    // to abort the current request and reset
+                    this.resetRequired = true;
+                }
                 if (this.populated) {
                     this.reset();
                 }
@@ -236,6 +249,11 @@
                 fetch(this._getUrl(feedType) + '?' + queryString)
                     .then(r => r.json())
                     .then(r => {
+                        // Abort the current request if a reset is required
+                        if (this.resetRequired) {
+                            this.reset();
+                            return;
+                        }
                         if (r.entries.length) {
                             r.entries.forEach(share => {
                                 if (share) {
@@ -249,11 +267,11 @@
                                 }
                             });
                             this.set('page', r.next);
-                            this.set('populated', true);
                             this.set('empty', false);
                         } else {
                             this.set('empty', true);
                         }
+                        this.set('populated', true);
                         this.set('fetching', false);
                         this.$.threshold.clearTriggers();
                     });
@@ -265,6 +283,7 @@
                 this.set('populated', false);
                 this.set('shares', []);
                 this.set('page', 0);
+                this.set('resetRequired', false);
                 this.set('selectedShare', {});
                 this._loadMoreData();
             },


### PR DESCRIPTION
Add a `resetRequired` flag to override the current fetch request and reset if the current user has changed while the request is being made. If the component is not fetching, and has already been populated, reset as normal. This feels slightly clumsy, but corrects an issue where users were being shown the shares of other users, or concatenations of user shares because the `userId` was only updating when the fetch request was already in progress. Setting a `resetRequired` flag allows the results of the existing request to be ignored, and a new request made with the updated user details.

Should fix this bug: https://trello.com/c/5v4YpJjr/452-first-time-going-in-on-a-user-who-does-not-have-any-pixel-kit-shares-you-see-other-peoples-pixel-kit-shares