### PR TITLE
Add user progress to `kano-session` and amend user progress displays

### DIFF
--- a/kano-session/kano-session.html
+++ b/kano-session/kano-session.html
@@ -49,6 +49,13 @@
                     value: false
                 },
                 /**
+                 * Set to true to include the user progress in the `profile`
+                 */
+                includeProgress: {
+                    type: Boolean,
+                    value: false
+                },
+                /**
                  * Exposes the status of the session. `initialising` ,`not-authenticated`, `authenticated`, `authenticating`, `expired`
                  */
                 status: {
@@ -61,7 +68,8 @@
                 '_sessionChanged(session)',
                 '_tokenChanged(token)',
                 '_userChanged(user)',
-                '_includeProfileChanged(includeProfile, session, token)'
+                '_includeProfileChanged(includeProfile, session, token)',
+                '_includeProgressChanged(includeProgress, session, token)'
             ],
             attached () {
                 Promise.all([
@@ -104,8 +112,37 @@
                                 this.status = 'not-authenticated';
                             });
                     }
+                    if (!promises['progress']) {
+                        var headers = new Headers();
+                            headers.append('Authorization', this.token);
+                        promises['progress'] = fetch(this._getUrl('progress'), {
+                            headers
+                        })
+                        .then(r => r.json());
+                    }
                     promises['profile'].then(res => {
-                        this.set('user', res.user);
+                        this.set('user.profile', res.user.profile);
+                        promises['progress'].then(res => {
+                            this.set('user.profile.levels', res.progress.levels);
+                        });
+                    });
+                }
+            },
+            _includeProgressChanged (value, session, token) {
+                if (value && session && token) {
+                    if (!promises['progress']) {
+                        var headers = new Headers();
+                            headers.append('Authorization', this.token);
+                        promises['progress'] = fetch(this._getUrl('progress'), {
+                            headers
+                        })
+                        .then(r => r.json());
+                    }
+                    promises['progress'].then(res => {
+                        if (!this.user.profile) {
+                            this.set('user.profile', {});
+                        }
+                        this.set('user.profile.levels', res.progress.levels);
                     });
                 }
             },

--- a/kano-user-menu/kano-user-menu.html
+++ b/kano-user-menu/kano-user-menu.html
@@ -378,7 +378,7 @@ Example:
                 type: Number,
                 readOnly: true,
                 notify: true,
-                computed: '_computeXP(user.profile.*)',
+                computed: '_computeXP(user.profile.levels)',
                 value: 0
             },
             /**
@@ -418,14 +418,14 @@ Example:
             },
             progress: {
                 type: Number,
-                computed: '_computeProgress(user.*)',
+                computed: '_computeProgress(user.profile.levels)',
                 readOnly: true,
                 notify: true,
                 value: 0
             },
             level: {
                 type: Number,
-                computed: '_computeLevel(user.profile.*)',
+                computed: '_computeLevel(user.profile.levels)',
                 readOnly: true,
                 notify: true
             }
@@ -442,26 +442,26 @@ Example:
         detached () {
             this.unlisten(document, 'tap', '_closeDropdowns');
         },
-        _computeLevel (user) {
-            if (!user || !user.base || !user.base.profile || !user.base.profile.levels) {
+        _computeLevel (levels) {
+            if (!levels) {
                 return 0;
             }
-            var levels = user.base.profile.levels;
             return levels.level;
         },
-        _computeProgress (user) {
-            if (!user || !user.base || !user.base.profile || !user.base.profile.levels) {
+        _computeProgress (levels) {
+            if (!levels) {
                 return 0;
             }
-            let levels = user.base.profile.levels,
-                xp = levels.xp,
+            let xp = levels.xp,
                 nextThreshold = levels['next-threshold'],
                 percent = (xp / nextThreshold) * 100;
             return percent.toFixed(2);
         },
-        _computeXP (profilePath) {
-            let profile = profilePath.base;
-            return profile && profile.levels && profile.levels.xp || 0;
+        _computeXP (levels) {
+            if (!levels) {
+                return 0;
+            }
+            return levels.xp || 0;
         },
         _isAuthenticated (user) {
             return !!user;

--- a/kano-user-stats/kano-user-stats.html
+++ b/kano-user-stats/kano-user-stats.html
@@ -226,7 +226,7 @@ Custom property | Description | Default
              */
             level: {
                 type: Number,
-                computed: '_computeLevel(user.profile.*)',
+                computed: '_computeLevel(user.profile.levels)',
                 readOnly: true
             },
             /**
@@ -234,7 +234,7 @@ Custom property | Description | Default
              */
             progress: {
                 type: Number,
-                computed: '_computeProgress(user.*)',
+                computed: '_computeProgress(user.profile.levels)',
                 observer: '_updateProgress',
                 readOnly: true,
                 notify: true
@@ -273,19 +273,17 @@ Custom property | Description | Default
             }
             return this.defaultAvatar;
         },
-        _computeLevel (user) {
-            if (!user || !user.base || !user.base.profile || !user.base.profile.levels) {
+        _computeLevel (levels) {
+            if (!levels) {
                 return 0;
             }
-            var levels = user.base.profile.levels;
             return levels.level;
         },
-        _computeProgress (user) {
-            if (!user || !user.base || !user.base.profile || !user.base.profile.levels) {
+        _computeProgress (levels) {
+            if (!levels) {
                 return 0;
             }
-            var levels = user.base.profile.levels,
-                xp = levels.xp,
+            var xp = levels.xp,
                 nextThreshold = levels['next-threshold'],
                 percent = xp / nextThreshold;
             return percent;


### PR DESCRIPTION
* Add `includeProgress` property to `kano-session` and `_includeProgressChanged` observer to fetch the progress of the current user
* Correct and simplify the way that the user XP and level are computed in `kano-user-menu` and `kano-user-stats` to use the gamified `progress` object in the user profile

Required for this PR: https://github.com/KanoComputing/kano2-app/pull/260

With the PR above, this should fix this bug: https://trello.com/c/h530wh0a/459-levels-not-being-shown-it-says-that-i-have-0-xp