### PR TITLE
Force tombstoned share cards to have default cursors and hidden usernames

### DIFF
--- a/kano-share-card/kano-share-card.html
+++ b/kano-share-card/kano-share-card.html
@@ -22,8 +22,8 @@
             }
             :host #cover {
                 background-color: var(--color-stone);
-                cursor: pointer;
             }
+            :host #cover,
             :host kano-lightboard-preview {
                 cursor: pointer;
             }
@@ -170,8 +170,11 @@
                 background-color: var(--color-stone);
                 color: transparent;
             }
+            :host([tombstone]) * {
+                cursor: default !important;
+            }
             :host([tombstone]) .username {
-                display: none;
+                display: none !important;
             }
         </style>
         <kano-session token="{{token}}" user="{{user}}"></kano-session>


### PR DESCRIPTION
When `kano-share-card`s have the `tombstone` property, nothing should be clickable, so the cursor should be `default`. The username should also not appear when hovering over the `#user` div, as this will be blank when tombstoned. `!important` seemed appropriate here to override the attributes on all children, and avoid unnecessary specificity.

Fixes this bug: https://trello.com/c/XxsnuB1U/484-hovering-over-user-icon-brings-up-a-blank-popup