### PR TITLE
Prepopulate share comment flags before making the fetch request

### DIFF
--- a/kano-share-wrapper/kano-share-wrapper-behavior.html
+++ b/kano-share-wrapper/kano-share-wrapper-behavior.html
@@ -55,6 +55,9 @@
                     headers = new Headers({
                         'Authorization': this.token,
                         'Content-Type': 'application/json'
+                    }),
+                    flagLength = this.push('selectedShare.comments.' + commentIndex + '.flags', {
+                        author: this.user.id
                     });
                 fetch(path, {
                     headers,
@@ -62,7 +65,9 @@
                 }).then(response  => response.json())
                   .then(response => {
                       if (response.success && response.flag) {
-                          this.push('selectedShare.comments.' + commentIndex + '.flags', response.flag);
+                          this.set(`selectedShare.comments.${commentIndex}.flags.${flagLength - 1}`, response.flag);
+                      } else {
+                          this.splice(`selectedShare.comments.${commentIndex}.flags`, flagLength - 1, 1);
                       }
                   });
             },


### PR DESCRIPTION
And update when the fetch request has completed. This makes the UI changes immediate and preserves them if the API call is successful – or resets if failed.

Trello card: https://trello.com/c/kaPnggx6/68-2-make-the-flag-to-customer-care-functionality-work-on-the-share-card-modal