### PR TITLE
Update user progress displays

### DIFF
--- a/kano-progress-bar/kano-progress-bar.html
+++ b/kano-progress-bar/kano-progress-bar.html
@@ -153,7 +153,7 @@ Custom property | Description | Default
                 var incrementUnit = targetValue > oldValue ? +1 : -1,
                     incrementing = setInterval(() => {
                         this.immediateValue = this.immediateValue + incrementUnit;
-                        if (this.immediateValue === targetValue) {
+                        if (this.immediateValue >= targetValue) {
                             this.startValue = this.immediateValue;
                             this.inProgress = false;
                             clearInterval(incrementing);

--- a/kano-user-menu/kano-user-menu.html
+++ b/kano-user-menu/kano-user-menu.html
@@ -420,8 +420,7 @@ Example:
                 type: Number,
                 computed: '_computeProgress(user.profile.levels)',
                 readOnly: true,
-                notify: true,
-                value: 0
+                notify: true
             },
             level: {
                 type: Number,
@@ -452,9 +451,7 @@ Example:
             if (!levels) {
                 return 0;
             }
-            let xp = levels.xp,
-                nextThreshold = levels['next-threshold'],
-                percent = (xp / nextThreshold) * 100;
+            let percent = levels.complete * 100;
             return percent.toFixed(2);
         },
         _computeXP (levels) {

--- a/kano-user-stats/kano-user-stats.html
+++ b/kano-user-stats/kano-user-stats.html
@@ -283,10 +283,7 @@ Custom property | Description | Default
             if (!levels) {
                 return 0;
             }
-            var xp = levels.xp,
-                nextThreshold = levels['next-threshold'],
-                percent = xp / nextThreshold;
-            return percent;
+            return levels.complete;
         },
         _computeStats (user) {
             var profile = user && user.profile;

--- a/kano-user-summary/kano-user-summary.html
+++ b/kano-user-summary/kano-user-summary.html
@@ -144,10 +144,9 @@ Example:
                 observer: '_updateBar'
             },
         },
-        _updateBar (currentProgress, previousProgress) {
-            previousProgress = previousProgress || 0;
-            let difference = currentProgress - previousProgress;
-            this.$.bar.addValue(difference);
+        _updateBar (currentProgress) {
+            this.$.bar.startValue = 0;
+            this.$.bar.addValue(currentProgress);
         }
     });
 </script>


### PR DESCRIPTION
User the `user.profile.levels.complete` value, rather than computing progress, in line with API intentions.

Also updates how the progress bar in the `kano-user-summary` is updated to fix problems switching between users.

Related to: https://trello.com/c/1I49gin4/224-level-indication-is-incorrect