### PR TITLE
Increase share limit for detailed shares

### DIFF
--- a/kano-share-feed/kano-share-feed.html
+++ b/kano-share-feed/kano-share-feed.html
@@ -214,7 +214,7 @@
                 var self = this,
                     feedType = this.feed,
                     filters = this.filters || {},
-                    limit = this.mode === 'detailed' ? 18 : 20,
+                    limit = this.mode === 'detailed' ? 18 : 36,
                     query = [
                         'page=' + this.page,
                         'limit=' + limit


### PR DESCRIPTION
Insufficient shares were being loaded in the detailed view, making the `iron-list` laggy and buggy. This increases the number of detailed shares loaded, which at worst mitigates the problem, but should sort this.

Trello card: https://trello.com/c/wlN9wqjp/520-my-creations-feed-when-full-the-top-items-appear-and-disappear