### PR TITLE
Only fade out placeholder when there are shares returned in kano-share-feed

### DIFF
--- a/kano-share-feed/kano-share-feed.html
+++ b/kano-share-feed/kano-share-feed.html
@@ -283,11 +283,11 @@
                             this.set('page', r.next);
                             this.set('populated', true);
                             this.set('empty', false);
+                            this.$.initial.style.opacity = 0;
                         } else {
                             this.set('empty', true);
                         }
                         this.set('fetching', false);
-                        this.$.initial.style.opacity = 0;
                         this.$.threshold.clearTriggers();
                         /**
                         * If there is no next page, then we are complete and


### PR DESCRIPTION
Avoids empty feeds with no tombstoning.

Trello card: https://trello.com/c/ajzbIHcK/712-p2-my-modes-null-modal-causes-tombstoned-my-modes-cards-to-disappear