### PR TITLE
Properly restart sessions in tracking behavior

### DIFF
--- a/kano-tracking/kano-tracking-behavior.html
+++ b/kano-tracking/kano-tracking-behavior.html
@@ -54,7 +54,8 @@
                 type: String
             },
             token: {
-                type: String
+                type: String,
+                observer: '_trackingTokenChanged'
             }
         },
         observers: [
@@ -264,6 +265,15 @@
                 }, true);
             }
             this.sessionStarted = true;
+        },
+        _trackingTokenChanged (current, previous) {
+            /**
+             * If there was a previous session, but not a new one – ie. the
+             * user has logged out – we want to trigger a new session
+             */
+            if (previous && !current) {
+                this._restartSession();
+            }
         },
         _trackBasicEvent (e) {
             let name = e.detail.name,


### PR DESCRIPTION
Previously, the tracking behavior was restarting the sessions correctly after 30 minutes of inactivity, but was not generating a new session ID, which somewhat undermined the point of this. This update ensures that sessions are properly re-initialized, and a new `sessionId` is generated when restarting the session.