### PR TITLE
Preserve session if offline

### DIFF
--- a/kano-session/kano-session.html
+++ b/kano-session/kano-session.html
@@ -115,7 +115,7 @@
                                     this.session = null;
                                     this.status = 'not-authenticated';
                                 }
-                                /** Clear the promise to we can try again */
+                                /** Clear the promise so we can try again */
                                 promises['profile'] = null;
                             });
                     }


### PR DESCRIPTION
* Break out `attached` functions to `init` to allow these to be called from parent (eg. when connection is restored).
* Clear promises when errors are caught, so that these can be tried again.
* Clear `token` and  `session` only if the browser is online. If not, we can assume that this is a connectivity error and the session should be preserved until the connection is restored and the authorisation can be tried again.

Required for this PR: https://github.com/KanoComputing/kano2-app/pull/410

Trello card: https://trello.com/c/Jv3MuT6C/747-2-as-a-kca-user-with-my-wifi-off-with-my-app-closed-if-i-open-my-app-for-the-2-session-i-should-be-asked-to-connect-by-computer