### PR TITLE
Changes to try and improve the speed and efficiency of the share feeds

### DIFF
--- a/kano-api-client-behavior/kano-api-client-behavior.html
+++ b/kano-api-client-behavior/kano-api-client-behavior.html
@@ -40,11 +40,12 @@
                     type: Object
                 },
                 context: {
-                    type: Object
+                    type: Object,
+                    value: () => Kano.World || Kano.App || {},
+                    observer: '_initClient'
                 }
             },
-            ready () {
-                this.context = Kano.World || Kano.App || {};
+            _initClient () {
                 this.config = this.config || this.context.config;
                 if (!this.context.config && !this.context.initialized) {
                     console.warn('No Kano configuration:\nPlease import a Kano.World or Kano.App config Object to use the API');

--- a/kano-share-card/kano-share-card.html
+++ b/kano-share-card/kano-share-card.html
@@ -194,7 +194,6 @@
                 display: none !important;
             }
         </style>
-        <kano-session token="{{token}}" user="{{user}}"></kano-session>
         <div class="wrapper">
             <div class="inner">
                 <div class="cover-wrapper">
@@ -270,6 +269,12 @@
                     type: String,
                     reflectToAttribute: true,
                     value: 'detailed'
+                },
+                token: {
+                    type: String
+                },
+                user: {
+                    type: Object
                 }
             },
             _coverWidth (mode) {

--- a/kano-share-feed/kano-share-feed.html
+++ b/kano-share-feed/kano-share-feed.html
@@ -3,7 +3,6 @@
 <link rel="import" href="../../iron-list/iron-list.html">
 <link rel="import" href="../../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../kano-api-client-behavior/kano-api-client-behavior.html">
-<link rel="import" href="../kano-session/kano-session.html">
 <link rel="import" href="../kano-share-card/kano-share-card.html">
 <link rel="import" href="../kano-style/kano-style.html">
 
@@ -62,10 +61,6 @@
         }
     </style>
     <template>
-        <kano-session id="session"
-                          token="{{token}}"
-                          user="{{user}}"
-                          include-profile></kano-session>
         <template is="dom-if" if="[[empty]]">
             <div class="message">
                 <slot id="placeholder" name="placeholder"> </slot>
@@ -96,6 +91,7 @@
                                          mode="[[mode]]"
                                          saved-shares="[[savedShares]]"
                                          selected-share="[[share]]"
+                                         token="[[token]]"
                                          user="[[user]]">
                                          </kano-share-card>
                     </template>
@@ -189,12 +185,10 @@
                  * content based on your user
                  */
                 token: {
-                    type: String,
-                    observer: '_handleChanges'
+                    type: String
                 },
                 user: {
-                    type: Object,
-                    observer: '_handleChanges'
+                    type: Object
                 }
             },
             attached () {
@@ -215,12 +209,10 @@
             _displayLoadingPlaceholder (populated, complete) {
                 return populated && !complete;
             },
-            _handleChanges () {
+            _handleChanges (change) {
                 if (this.fetching) {
                     this.request.cancel();
-                    this.reset();
-                }
-                if (this.populated) {
+                } else {
                     this.reset();
                 }
             },
@@ -228,10 +220,11 @@
                 return mode === 'detailed';
             },
             _loadMoreData () {
-                // When we hit the last page
-                if (this.page === null) {
+                /** When we hit the last page, or we're already fetching */
+                if (this.page === null || this.fetching) {
                     return;
                 }
+
                 this.set('fetching', true);
                 var self = this,
                     feedType = this.feed,
@@ -289,9 +282,9 @@
                         this.set('fetching', false);
                         this.$.threshold.clearTriggers();
                         /**
-                        * If there is no next page, then we are complete and
-                        * won't be able to fetch any more pages
-                        */
+                         * If there is no next page, then we are complete and
+                         * won't be able to fetch any more pages
+                         */
                         if (r.next === null) {
                             this.complete = true;
                         }
@@ -299,6 +292,9 @@
                     .catch(e => {
                         this.set('fetching', false);
                         this.$.threshold.clearTriggers();
+                        if (e.cancelled) {
+                            this.reset();
+                        }
                     });
             },
             _makeRequestCancelable (promise) {

--- a/kano-share/kano-share-behavior.html
+++ b/kano-share/kano-share-behavior.html
@@ -51,7 +51,7 @@
                 },
                 sharedByUser: {
                     type: Boolean,
-                    computed: '_sharedByUser(selectedShare, user)'
+                    computed: '_sharedByUser(selectedShare, user.id)'
                 }
             },
             observers: [
@@ -118,11 +118,11 @@
                 }
                 return savedShares.indexOf(selectedShare.id) > -1;
             },
-            _sharedByUser (share, user) {
-                if (!share || !user) {
+            _sharedByUser (share, userId) {
+                if (!share || !userId) {
                     return false;
                 }
-                return share.user && share.user.id === user.id;
+                return share.user && share.user.id === userId;
             },
             _shareContainsAnimation (share) {
                 if (!share || !share.attachments) {


### PR DESCRIPTION
* Pass down the user and token from parent components rather than allowing the `kano-share-feed` or `kano-share-card` to manage these themselves – this helps prevent the share feed making multiple cancelled requests when properties update, and instead just relies on a few key changes from the parent.
* Improves the cancellation of share feed requests, and resets the feed once a request has been successfully cancelled – this stops requests being cancelled multiple times, or being triggered again before they have been successfully cancelled.
* Removes some outdated properties.

Sister PR to: https://github.com/KanoComputing/kano2-app/pull/477