### PR TITLE
Introduce promise-based method to set up the session or reject with no token

### DIFF
--- a/kano-session/kano-session.html
+++ b/kano-session/kano-session.html
@@ -138,6 +138,25 @@
                 promises = {};
                 this.fire('logout');
             },
+            reinitialize () {
+                return this.init().then(session => {
+                    if (!this.token) {
+                        return Promise.reject();
+                    }
+                    var headers = new Headers();
+                    headers.append('Authorization', this.token);
+                    if (!promises['session']) {
+                        this.status = 'authenticating';
+                        promises['session'] = fetch(this._getUrl('session'), { headers })
+                            .then(r => r.json());
+                    }
+                    return promises['session'].then(res => {
+                        this.set('user', res.session.user);
+                        this.status = 'authenticated';
+                        return Promise.resolve(res.session.user);
+                    });
+                });
+            },
             _retrieveSession () {
                 if (!this.token) {
                     return;


### PR DESCRIPTION
The previous strategy when checking for the user when showing the device page was causing issues with the promise resolution and the actual data being checked being out of sync. To try to avoid any problems, I have introduced a new promise based method separate from other methods to ensure that the user has been initialized. The also avoids errors in Polymer for Promise rejections not being handled when promise functions are used as observers.

This should fix the issues in the Trello card below, where the user was still being checked before being initialized and the user was being prompted to log in unnecessarily.

Required for this PR: https://github.com/KanoComputing/kano2-app/pull/514

Trello card: https://trello.com/c/CHFFCnjC/1004-p2-rc24-win10-rpk-about-every-3-4-times-you-start-kca-you-have-to-log-in-again