### PR TITLE
Changing order of possible contexts

### DIFF
--- a/kano-tracking/kano-tracking-behavior.html
+++ b/kano-tracking/kano-tracking-behavior.html
@@ -67,7 +67,7 @@
             'tracking-event': '_trackBasicEvent'
         },
         ready () {
-            this.context = Kano.World || Kano.App || Kano.MakeApps || {};
+            this.context = Kano.MakeApps || Kano.World || Kano.App || {};
             this.config = this.config || this.context.config;
             if (!this.config && !this.context.initialized) {
                 console.warn('No Kano configuration:\nPlease import a Kano.World or Kano.App config Object to use tracking');


### PR DESCRIPTION
The problem:
- using this behavior in Kano Code IDE through the Kano2 app, the ```this.context``` was 'Kano.App'

The solution:
- change the order of the possible objects to assign to the ```this.context```