### PR TITLE
Allow the context to be specified in the tracking behavior

### DIFF
--- a/kano-tracking/kano-tracking-behavior.html
+++ b/kano-tracking/kano-tracking-behavior.html
@@ -67,7 +67,11 @@
             'tracking-event': '_trackBasicEvent'
         },
         ready () {
-            this.context = Kano.MakeApps || Kano.World || Kano.App || {};
+            this.context = this.context ||
+                           Kano.MakeApps ||
+                           Kano.World ||
+                           Kano.App ||
+                           {};
             this.config = this.config || this.context.config;
             if (!this.config && !this.context.initialized) {
                 console.warn('No Kano configuration:\nPlease import a Kano.World or Kano.App config Object to use tracking');
@@ -88,6 +92,7 @@
                     'Content-Type': 'application/json'
                 }),
                 body = {
+                    app_id: this.config.APP_ID,
                     app_version: this.config.VERSION,
                     browser_id: this.browserId,
                     page_path: this.path || '',


### PR DESCRIPTION
Also sets the `app_id` in the tracking payload.

This addresses issues with the tracking behavior and selecting the incorrect context when sharing the behavior between apps.