### PR TITLE
Fix slotted syling of kano-alert buttons in shady DOM

### DIFF
--- a/kano-alert/kano-alert.html
+++ b/kano-alert/kano-alert.html
@@ -14,7 +14,7 @@ Example:
     <kano-alert heading=""
                        text=""
                        icon-color="">
-        <div slot="icon"></div>               
+        <div slot="icon"></div>
         <div slot="actions"></div>
     </kano-alert>
 
@@ -108,8 +108,8 @@ Custom property | Description | Default
                 @apply --kano-alert-action-container;
             }
             .actions button,
-            ::slotted(button.kano-alert-primary),
-            ::slotted(button.kano-alert-secondary) {
+            .actions ::slotted(button.kano-alert-primary),
+            .actions ::slotted(button.kano-alert-secondary) {
                 @apply --kano-button;
                 border-radius: 3px;
                 font-family: var(--font-body);
@@ -123,24 +123,20 @@ Custom property | Description | Default
                 margin-right: 12px;
             }
             .actions button.primary,
-            ::slotted(button.kano-alert-primary) {
+            .actions ::slotted(button.kano-alert-primary) {
                 background: #ff6900;
                 color: #fff;
             }
             .actions button.primary:hover,
-            ::slotted(button.kano-alert-primary:hover),
-            .actions button.primary:focus,
-            ::slotted(button.kano-alert-primary:focus) {
+            .actions ::slotted(button.kano-alert-primary:hover) {
                 background-color: #ff7d14;
             }
             .actions button.secondary,
-            ::slotted(button.kano-alert-secondary) {
+            .actions ::slotted(button.kano-alert-secondary) {
                 background: #e1e1e1;
             }
             .actions button.secondary:hover,
-            ::slotted(button.kano-alert-secondary:hover),
-            .actions button.secondary:focus,
-            ::slotted(button.kano-alert-secondary:focus) {
+            .actions ::slotted(button.kano-alert-secondary:hover) {
                 background: #e9e9e9;
             }
         </style>


### PR DESCRIPTION
The buttons weren't styled properly in shady dom (in safari):

Context here: https://www.polymer-project.org/2.0/docs/devguide/style-shadow-dom#style-slotted-content-distributed-children